### PR TITLE
Add support for multi rom titles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Make a backup of your ROMs before using the --delete flag!
 
 This is a simple script that will go through your ROM collection, and propose removal of duplicate titles based on their file name.
 
-It is guaranteed to keep 1 (and only 1) ROM of each title.
+It is guaranteed to keep 1 (and only 1) ROM of each title, except when the candidate title has multiple volume, where 
+all related volumes will be kept.
 
 For instance (this is safe to run... you need to explicity put the **--delete** flag actually delete stuff.)
 
@@ -34,13 +35,25 @@ Games are ranked first according to the reported build, for example a revision i
 in turn is ranked higher than a alpha. Between different revisions or versions their number is used to break ties.
 
 The second ranking criteria is game region, which by default prioritizes USA and European titles, region preference is customized through 
-the --regions argument, default: 'U,E' - regions are case sensitive.
+the --regions argument.
 
 The third ranking criteria is timestamp, mostly used to sort between prototypes and betas.
 
+```
+usage: clean_roms.py [-h] [--regions REGIONS] [--rom_dir ROM_DIR] [--ignore_dirs IGNORE_DIRS] [--delete]
+
+options:
+  -h, --help            show this help message and exit
+  --regions REGIONS     Preferences for sorting: USA, Europe, case sensistive. (default: U,E)
+  --rom_dir ROM_DIR     Location where your roms are stored. (default: y://)
+  --ignore_dirs IGNORE_DIRS
+                        List of subdirectories to ignore (default: images,videos,manuals)
+  --delete              WARNING: setting this will delete the roms! (default: False)
+```
+
 The script it's geared towards English, but feel free to modify it:
 
-When you are happy with list of "KO" (aka, the files that the script will delete), run it like so:
+When you are happy with list of "KO" (aka, the files that the script will delete), run with the delete flag:
 
 ```bash
 python clean_roms.py --regions U,E --rom_dir /Volumes/roms -- --delete


### PR DESCRIPTION
Added support for multiple disc rom archives, if the rom is properly named related volumes will be kept during the procedure, for example if the rom has tag (Disc 1), roms with the same name but different number will be spared, same for  (Side A, Side B...) format.
Added an extra argument to customize the list of subdirectories to ignore, for example to ignore metadata information like images, videos or manuals.
The script will now halt and give feedback to the user when unmatched parenthesis or brackets are found, for a chance to correct the culprit name.   
Fixed bugs and improved build rank functionality, '!' builds will now be prioritized over roms that dont have this sign.